### PR TITLE
init helm template - poc

### DIFF
--- a/helm/ukur-demo/Chart.yaml
+++ b/helm/ukur-demo/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+name: ukur-demo
+version: '0.0.1'
+appVersion: 'release-0.0.1'
+description: ukur-demo is something
+keywords:
+- ukur-demo
+sources:
+- https://github.com/entur/ukur-demo
+maintainers:
+- name: 'Team: ror'
+  email: team.rutedata@entur.org
+engine: gotpl

--- a/helm/ukur-demo/README.md
+++ b/helm/ukur-demo/README.md
@@ -1,0 +1,61 @@
+## Introduction
+
+This chart will setup the `ukur-demo` app and it's dependencies in a given namespace.
+
+## Prerequisites
+
+Download Helm version >v2.12.0 https://github.com/kubernetes/helm
+
+```
+$ helm init --client-only
+$ helm repo add entur https://entur-helm-charts.storage.googleapis.com
+$ helm dependency update
+```
+
+## Installing the Chart
+
+To see the template output before deploying:
+```bash
+$ helm template ./ --name ukur-demo-dev  --values values.yaml --namespace dev
+```
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install ./ --name <release-name> --namespace my-namespace
+```
+Watch the deployment with this command
+
+```bash
+$ kubectl get svc <release-name> --namespace my-namespace -w
+```
+
+## Uninstalling the Chart
+
+To completely remove `my-release`:
+
+```bash
+$ helm delete <release-name> --purge
+```
+
+## Updating a chart
+
+Use `--reuse-values` if you want to keep values set on earlier install/upgrade. Values can be checked using this command:
+```bash
+$ helm get values <release-name>
+```
+
+#### From remote repository
+```bash
+$ helm update
+$ helm upgrade <release-name> entur/ukur-demo
+```
+
+#### From local chart
+```bash
+$ helm upgrade --set imageTag=<image-tag e.g. master-v40> ./ukur-demo
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the order chart and their default values.

--- a/helm/ukur-demo/templates/_helpers.tpl
+++ b/helm/ukur-demo/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ukur-demo.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "ukur-demo.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Generate basic labels */}}
+{{- define "common.labels" }}
+app: {{ .Values.app }}
+version: {{ .Chart.Version }}
+team: {{ .Values.team }}
+slack: {{ .Values.slack }}
+type: {{ .Values.type }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+release: {{ .Release.Name }}
+api: {{ .Values.api }}
+{{- end }}
+

--- a/helm/ukur-demo/templates/configmap.yaml
+++ b/helm/ukur-demo/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  application.properties: |+
+    ukur.subscription.url=http://ukur/external/subscription
+    push.baseurl=http://ukur-demo/push
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/ukur-demo/templates/deployment.yaml
+++ b/helm/ukur-demo/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "common.labels" . | indent 4 }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.minReplicas }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "common.labels" . | indent 8 }}
+    spec:
+      containers:
+      - command:
+        - /deployments/run-java.sh
+        env:
+        - name: TZ
+          value: Europe/Oslo
+        - name: JAVA_OPTIONS
+          value: -server -Dspring.config.additional-location=/etc/application-config/application.properties
+            -Xmx{{ .Values.resources.xmx }} -Dserver.port={{ .Values.service.internalPort }} -Dfile.encoding=UTF-8 -Drutebanken.kubernetes.namespace={{ .Release.Namespace }}
+        image: {{ .Values.image }}:{{ .Values.imageTag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: health/live
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 20
+        name: {{ .Chart.Name }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+          name: http
+          protocol: TCP
+        - containerPort: {{ .Values.service.internalJolokiaPort}}
+          name: jolokia
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: health/ready
+            port: {{ .Values.service.internalPort }}
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 20
+        resources:
+          limits:
+            cpu: {{ .Values.resources.cpuLimit }}
+            memory: {{ .Values.resources.memLimit }}
+          requests:
+            cpu: {{ .Values.resources.cpuRequest }}
+            memory: {{ .Values.resources.memRequest }}
+        volumeMounts:
+        - mountPath: /etc/application-config
+          name: {{ .Values.app }}-config
+          readOnly: true
+      restartPolicy: Always
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: {{ .Values.app }}-config
+        name: {{ .Values.app }}-config

--- a/helm/ukur-demo/templates/horisontalPodAutoscaler.yaml
+++ b/helm/ukur-demo/templates/horisontalPodAutoscaler.yaml
@@ -1,0 +1,15 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    {{- include "common.labels" . | indent 4 }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  maxReplicas: {{ .Values.maxReplicas }}
+  minReplicas: {{ .Values.minReplicas }}
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: {{ .Release.Name }}
+  targetCPUUtilizationPercentage: 80 

--- a/helm/ukur-demo/templates/ingress.yaml
+++ b/helm/ukur-demo/templates/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  labels:
+    {{- include "common.labels" . | indent 4 }}
+  annotations:
+    {{- if eq .Release.Namespace "dev" }}
+    external-dns.alpha.kubernetes.io/target: {{ .Values.externalDns.ingressLoadBalancerIP.dev }}
+    {{- else if eq .Release.Namespace "staging" }}
+    external-dns.alpha.kubernetes.io/target: {{ .Values.externalDns.ingressLoadBalancerIP.staging }}
+    {{- else if eq .Release.Namespace "production" }}
+    external-dns.alpha.kubernetes.io/target: {{ .Values.externalDns.ingressLoadBalancerIP.production }}
+    {{- end }}
+    kubernetes.io/ingress.class: traefik
+  name: {{ .Release.Name }}-{{ .Values.api }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  rules:
+    {{- if eq .Release.Namespace "dev" }}
+    - host: {{ .Values.app }}-{{ .Values.api }}-{{ .Release.Namespace }}.dev.entur.io
+    {{- else if eq .Release.Namespace "staging" }}
+    - host: {{ .Values.app }}-{{ .Values.api }}-{{ .Release.Namespace }}.staging.entur.io
+    {{- else if eq .Release.Namespace "staging" }}
+    - host: {{ .Values.app }}-{{ .Values.api }}-{{ .Release.Namespace }}.entur.io
+    {{- end }}
+      http:
+        paths:
+        - backend:
+            serviceName: {{ .Release.Name }}
+            servicePort: {{ .Values.service.externalPort }}

--- a/helm/ukur-demo/templates/service.yaml
+++ b/helm/ukur-demo/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "common.labels" . | indent 4 }}
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: http
+    port: {{ .Values.service.externalPort }}
+    protocol: TCP
+    targetPort: {{ .Values.service.internalPort }}
+  - name: debug
+    port: {{ .Values.service.debugPort }}
+    protocol: TCP
+    targetPort: {{ .Values.service.debugPort }}
+  selector:
+    app: {{ .Release.Name }}
+  sessionAffinity: None
+  type: ClusterIP

--- a/helm/ukur-demo/values.yaml
+++ b/helm/ukur-demo/values.yaml
@@ -1,0 +1,31 @@
+minReplicas: 1
+maxReplicas: 1
+image: eu.gcr.io/entur-system-1287/ukur-demo
+imageTag: release-0.0.1
+imagePullPolicy: Always
+slack: talk-ror
+team: ror
+type: backend
+app: ukur-demo
+api: realtime-deviations-demo-v1
+service:
+  name: ukur-demo
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8080
+  internalJolokiaPort: 8778
+  debugPort: 5005
+resources:
+  cpuLimit: "2"
+  memLimit: 2048Mi
+  cpuRequest: 200m
+  memRequest: 512Mi
+  xmx: 1024m
+
+# Environment Specific
+externalDns:
+  ingressLoadBalancerIP: 
+    dev: "35.195.223.29"
+    staging: "35.195.146.93"
+    production: "35.187.15.14"
+


### PR DESCRIPTION
Here is a poc for ukur-demo that is scalable in the sense of amount of environments/namespaces.

Please note that the ingress hostname is dynamic, and at the moment not in sync with apigee implementation. However, that can be changed both in ingress and/or apigee. it could be random hash-like hostname if you like.

Additionally, I recommend start using the namespace standards as the rest of the organisation: dev/stagin/production, instead of "default".

Example below:

```
helm template ./ --name ukur-demo-dev  --values values.yaml --namespace dev | pbcopy
---
# Source: ukur-demo/templates/configmap.yaml
apiVersion: v1
data:
  application.properties: |+
    ukur.subscription.url=http://ukur/external/subscription
    push.baseurl=http://ukur-demo/push
kind: ConfigMap
metadata:
  name: ukur-demo-dev
  namespace: dev
---
# Source: ukur-demo/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  labels:    
    app: ukur-demo
    version: 0.0.1
    team: ror
    slack: talk-ror
    type: backend
    chart: ukur-demo-0.0.1
    release: ukur-demo-dev
    api: realtime-deviations-demo-v1
  name: ukur-demo-dev
  namespace: dev
spec:
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: 8080
  - name: debug
    port: 5005
    protocol: TCP
    targetPort: 5005
  selector:
    app: ukur-demo-dev
  sessionAffinity: None
  type: ClusterIP

---
# Source: ukur-demo/templates/deployment.yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  labels:    
    app: ukur-demo
    version: 0.0.1
    team: ror
    slack: talk-ror
    type: backend
    chart: ukur-demo-0.0.1
    release: ukur-demo-dev
    api: realtime-deviations-demo-v1
  name: ukur-demo-dev
  namespace: dev
spec:
  replicas: 1
  revisionHistoryLimit: 2
  selector:
    matchLabels:
      app: ukur-demo-dev
  strategy:
    type: Recreate
  template:
    metadata:
      labels:        
        app: ukur-demo
        version: 0.0.1
        team: ror
        slack: talk-ror
        type: backend
        chart: ukur-demo-0.0.1
        release: ukur-demo-dev
        api: realtime-deviations-demo-v1
    spec:
      containers:
      - command:
        - /deployments/run-java.sh
        env:
        - name: TZ
          value: Europe/Oslo
        - name: JAVA_OPTIONS
          value: -server -Dspring.config.additional-location=/etc/application-config/application.properties
            -Xmx1024m -Dserver.port=8080 -Dfile.encoding=UTF-8 -Drutebanken.kubernetes.namespace=dev
        image: eu.gcr.io/entur-system-1287/ukur-demo:release-0.0.1
        imagePullPolicy: Always
        livenessProbe:
          failureThreshold: 3
          httpGet:
            path: health/live
            port: 8080
            scheme: HTTP
          initialDelaySeconds: 60
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 20
        name: ukur-demo
        ports:
        - containerPort: 8080
          name: http
          protocol: TCP
        - containerPort: 8778
          name: jolokia
          protocol: TCP
        readinessProbe:
          failureThreshold: 3
          httpGet:
            path: health/ready
            port: 8080
            scheme: HTTP
          initialDelaySeconds: 30
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 20
        resources:
          limits:
            cpu: 2
            memory: 2048Mi
          requests:
            cpu: 200m
            memory: 512Mi
        volumeMounts:
        - mountPath: /etc/application-config
          name: ukur-demo-config
          readOnly: true
      restartPolicy: Always
      volumes:
      - configMap:
          defaultMode: 420
          name: ukur-demo-config
        name: ukur-demo-config
---
# Source: ukur-demo/templates/ingress.yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  labels:    
    app: ukur-demo
    version: 0.0.1
    team: ror
    slack: talk-ror
    type: backend
    chart: ukur-demo-0.0.1
    release: ukur-demo-dev
    api: realtime-deviations-demo-v1
  annotations:
    external-dns.alpha.kubernetes.io/target: 35.195.223.29
    kubernetes.io/ingress.class: traefik
  name: ukur-demo-dev-realtime-deviations-demo-v1
  namespace: dev
spec:
  rules:
    - host: ukur-demo-realtime-deviations-demo-v1-dev.dev.entur.io
      http:
        paths:
        - backend:
            serviceName: ukur-demo-dev
            servicePort: 80
---
# Source: ukur-demo/templates/horisontalPodAutoscaler.yaml
apiVersion: autoscaling/v1
kind: HorizontalPodAutoscaler
metadata:
  labels:    
    app: ukur-demo
    version: 0.0.1
    team: ror
    slack: talk-ror
    type: backend
    chart: ukur-demo-0.0.1
    release: ukur-demo-dev
    api: realtime-deviations-demo-v1
  name: ukur-demo-dev
  namespace: dev
spec:
  maxReplicas: 1
  minReplicas: 1
  scaleTargetRef:
    apiVersion: extensions/v1beta1
    kind: Deployment
    name: ukur-demo-dev
  targetCPUUtilizationPercentage: 80 


```